### PR TITLE
(Fix) 채팅 메시지 Redis 캐싱 오류 🐛

### DIFF
--- a/src/main/java/com/seven/marketclip/chat/dto/ChatMessagesDto.java
+++ b/src/main/java/com/seven/marketclip/chat/dto/ChatMessagesDto.java
@@ -2,10 +2,12 @@ package com.seven.marketclip.chat.dto;
 
 import com.seven.marketclip.chat.domain.ChatMessages;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 import java.util.Date;
 
 @Data
+@NoArgsConstructor
 public class ChatMessagesDto {
     private Long messageId;
     private String chatRoomId;


### PR DESCRIPTION
에러 문구
cannot deserialize from Object value (no delegate- or property-based Creator) 
생성자가 없어서 발생한 오류 @NoArgsConstructor 또는 기본 생성자 추가